### PR TITLE
Fix reservation date selection timezone bug

### DIFF
--- a/app-premium.js
+++ b/app-premium.js
@@ -216,7 +216,12 @@ function fillAvailableDates() {
 
     availableDates.forEach(date => {
         const option = document.createElement('option');
-        option.value = date.toISOString().split('T')[0];
+
+        // Format value manually to avoid timezone-related date shifts
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        option.value = `${year}-${month}-${day}`;
         const dayName = date.toLocaleDateString('de-AT', { weekday: 'long' });
         const formattedDate = date.toLocaleDateString('de-AT', {
             day: 'numeric',


### PR DESCRIPTION
## Summary
- avoid using `toISOString` when generating reservation date options
- ensure the reservation form submits the selected date without a timezone shift

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9f1c60e6c832d9571ee71f03978f7