### PR TITLE
Remove redundant Netlify form submission fallback

### DIFF
--- a/app-premium.js
+++ b/app-premium.js
@@ -213,19 +213,8 @@ function initReservationForm() {
                 });
 
                 if (!emailResponse.ok) {
-                    throw new Error('Email dispatch failed');
-                }
-
-                const netlifyResponse = await fetch('/', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/x-www-form-urlencoded'
-                    },
-                    body: encodeFormData(formData)
-                });
-
-                if (!netlifyResponse.ok) {
-                    throw new Error('Form submission failed');
+                    const errorData = await emailResponse.json();
+                    throw new Error(errorData.message || 'Email dispatch failed');
                 }
 
                 form.reset();


### PR DESCRIPTION
## Summary
- remove the extra Netlify Forms POST from the reservation form handler
- surface error details from the reservation email function when available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db08f4df34832d975eac2d6fd949a5