### PR TITLE
Fix available date time configuration

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -199,7 +199,12 @@ collections:
         name: "slots"
         widget: "list"
         fields:
-          - {label: "Zeit", name: "time", widget: "string", pattern: ["^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$", "Format: HH:MM"]}
+          - label: "Zeit"
+            name: "time"
+            widget: "text"
+            hint: "Format: HH:MM (z.B. 09:00, 14:30)"
+            default: "09:00"
+            pattern: ["^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$", "Bitte Format HH:MM verwenden"]
           - {label: "Max. Gäste", name: "max_guests", widget: "number", default: 20}
       - {label: "Notiz", name: "note", widget: "text", required: false, hint: "Wird Kunden angezeigt"}
 

--- a/content/available-dates/2025-10-06.md
+++ b/content/available-dates/2025-10-06.md
@@ -3,5 +3,7 @@ date: 2025-10-06
 title: Montags Brunch
 slots:
   - max_guests: 20
-    time: 9:00
+    time: "09:00"
+  - max_guests: 20
+    time: "10:00"
 ---


### PR DESCRIPTION
## Summary
- switch the available date slot time field to a text widget with HH:MM guidance and default value
- correct Monday brunch slot entries to quote times to satisfy string validation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc10223c98832dbeea2d5ce4cd23fa