### PR TITLE
Adjust hero logo sizing and footer content

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,19 +351,6 @@
             </div>
             
             <div class="footer-section">
-                <h4>öffnungszeiten</h4>
-                <p class="hours">
-                    <strong>sonntag</strong><br>
-                    09:00 - 12:00 uhr<br>
-                    <span class="hours-note">reservierung empfohlen</span>
-                </p>
-                <p class="closed">
-                    <strong>montag - samstag</strong><br>
-                    geschlossen
-                </p>
-            </div>
-            
-            <div class="footer-section">
                 <h4>kontakt</h4>
                 <address>
                     gumpendorfer straße 9<br>

--- a/mystyle-premium.css
+++ b/mystyle-premium.css
@@ -272,6 +272,12 @@ h1, h2, h3, h4, h5, h6 {
     line-height: 1.1;
     margin-bottom: var(--spacing-lg);
 }
+.hero-title .main-logo {
+    display: block;
+    width: clamp(110px, 18vw, 220px);
+    margin: var(--spacing-sm) auto;
+    height: auto;
+}
 .hero-subtitle {
     display: block;
     font-family: var(--font-light);
@@ -1218,6 +1224,12 @@ h1, h2, h3, h4, h5, h6 {
 }
 .about-content {
     padding-right: var(--spacing-lg);
+    text-align: left;
+}
+.about-content .section-title {
+    text-align: center;
+    margin-left: auto;
+    margin-right: auto;
 }
 .about-lead {
     font-family: var(--font-heading);


### PR DESCRIPTION
## Summary
- remove the published opening hours block from the footer
- reduce the hero logo footprint for desktop and mobile layouts
- center the "unsere geschichte" heading while keeping the surrounding copy left-aligned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc4f6b2594832db09c89b6b4cd522a