### PR TITLE
Add fallback availability when Netlify Blobs are unavailable

### DIFF
--- a/netlify/functions/get-availability.js
+++ b/netlify/functions/get-availability.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const fs = require('fs').promises;
+const path = require('path');
 const { getAvailability } = require('./utils/reservation-utils');
 
 const DEFAULT_HEADERS = {
@@ -15,6 +17,60 @@ function createResponse(statusCode, body) {
     headers: DEFAULT_HEADERS,
     body: JSON.stringify(body)
   };
+}
+
+const WEEKDAY_KEYS = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+
+function parseDateKey(date) {
+  if (!date || typeof date !== 'string') return null;
+  const [year, month, day] = date.split('-').map(Number);
+  if (!year || !month || !day) return null;
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+async function loadFallbackConfig() {
+  try {
+    const filePath = path.join(process.cwd(), 'content', 'reservierung', 'standard.json');
+    const raw = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(raw);
+  } catch (error) {
+    console.warn('Fallback-Konfiguration konnte nicht geladen werden.', error);
+    return null;
+  }
+}
+
+async function buildFallbackAvailability({ date, guests }) {
+  const config = await loadFallbackConfig();
+  const fallbackTimezone = (config && config.timezone) || 'Europe/Vienna';
+  const defaultCapacity = Number(config?.max_guests_per_reservation) || 20;
+
+  const parsedDate = parseDateKey(date);
+  if (!parsedDate) {
+    return { date, timezone: fallbackTimezone, slots: [] };
+  }
+
+  const dayKey = WEEKDAY_KEYS[parsedDate.getUTCDay()];
+  const opening = config?.opening_hours?.[dayKey];
+
+  if (!opening || opening.open === false) {
+    return { date, timezone: fallbackTimezone, slots: [] };
+  }
+
+  const slots = (opening.slots || []).map((slot) => {
+    const slotCapacity = Number(slot.capacity || slot.max_guests || opening.max_guests || defaultCapacity);
+    const remaining = Math.max(slotCapacity, 0);
+    const fits = guests ? remaining >= Number(guests) : remaining > 0;
+    return {
+      time: slot.time,
+      capacity: slotCapacity,
+      reserved: 0,
+      remaining,
+      waitlist: remaining === 0,
+      fits
+    };
+  });
+
+  return { date, timezone: fallbackTimezone, slots };
 }
 
 // CMS Blockierungen laden - MUSS VOR handler definiert werden
@@ -87,9 +143,15 @@ exports.handler = async (event) => {
 
     return createResponse(200, availability);
   } catch (error) {
+    if (error && (error.name === 'MissingBlobsEnvironmentError' || error.message?.includes('Netlify Blobs'))) {
+      console.warn('Netlify Blobs Umgebung fehlt – nutze statische Fallback-Verfügbarkeit.');
+      const fallback = await buildFallbackAvailability({ date, guests: guests ? parseInt(guests, 10) : null });
+      return createResponse(200, fallback);
+    }
+
     console.error('Fehler in get-availability:', error);
     console.error('Stack trace:', error.stack); // Mehr Debug-Info
-    return createResponse(500, { 
+    return createResponse(500, {
       message: 'Interner Server Fehler',
       error: process.env.NODE_ENV === 'development' ? error.message : undefined
     });


### PR DESCRIPTION
## Summary
- add a static fallback availability builder when Netlify Blobs is not configured
- return fallback time slots instead of an error so the widget still renders availability

## Testing
- node -e "require('./netlify/functions/get-availability.js').handler({httpMethod:'GET',queryStringParameters:{date:'2024-06-01'}}).then(r=>console.log(r)).catch(e=>console.error(e))"

------
https://chatgpt.com/codex/tasks/task_e_68e439f36588832db54f59e7d85889ad