### PR TITLE
Fix reservation availability loading from CMS data

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -198,24 +198,24 @@ collections:
       - label: "Zeitslots"
         name: "slots"
         widget: "list"
+        summary: "{{fields.time}} - {{fields.capacity}} Plätze"
         fields:
-          - label: "Zeit"
-            name: "time"
-            widget: "text"
-            hint: "Format: HH:MM (z.B. 09:00, 14:30)"
-            default: "09:00"
-            pattern: ["^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$", "Bitte Format HH:MM verwenden"]
-          - {label: "Max. Gäste", name: "max_guests", widget: "number", default: 20}
-      - {label: "Notiz", name: "note", widget: "text", required: false, hint: "Wird Kunden angezeigt"}
+          - {label: "Zeit", name: "time", widget: "string", hint: "z.B. 09:00"}
+          - {label: "Kapazität", name: "capacity", widget: "number", default: 20, min: 0}
 
-  - name: "blocked_reservations"
-    label: "Blockierte Reservierungen"
+  - name: "blocked-reservations"
+    label: "Blockierte Zeitslots"
+    label_singular: "Blockierter Zeitslot"
     folder: "content/blocked-reservations"
     create: true
-    identifier_field: "title"
+    slug: "{{year}}-{{month}}-{{day}}"
+    identifier_field: date
     fields:
-      - {label: "Titel", name: "title", widget: "string"}
-      - {label: "Datum", name: "date", widget: "datetime", format: "YYYY-MM-DD", dateFormat: "DD.MM.YYYY", timeFormat: false}
-      - {label: "Zeit", name: "time", widget: "string"}
-      - {label: "Anzahl blockierte Plätze", name: "blocked_seats", widget: "number"}
-      - {label: "Grund", name: "reason", widget: "text", required: false}
+      - {label: "Datum", name: "date", widget: "date", format: "YYYY-MM-DD"}
+      - label: "Blockierte Slots"
+        name: "blockedSlots"
+        widget: "list"
+        fields:
+          - {label: "Zeit", name: "time", widget: "select", options: ["09:00", "09:30", "10:00", "10:30", "11:00", "11:30", "12:00", "12:30", "13:00", "13:30", "14:00", "14:30", "15:00", "15:30", "16:00", "16:30", "17:00", "17:30", "18:00", "18:30", "19:00", "19:30", "20:00", "20:30"]}
+          - {label: "Blockierte Plätze", name: "blocked_seats", widget: "number", min: 0, max: 40}
+          - {label: "Grund", name: "reason", widget: "string", required: false, hint: "Optional: Grund für Blockierung"}

--- a/content/blocked-reservations/2025-01-15.md
+++ b/content/blocked-reservations/2025-01-15.md
@@ -1,0 +1,10 @@
+---
+date: 2025-01-15
+blockedSlots:
+  - time: "12:00"
+    blocked_seats: 20
+    reason: "Private Event"
+  - time: "12:30"
+    blocked_seats: 20
+    reason: "Private Event"
+---

--- a/content/settings/reservation-settings.yml
+++ b/content/settings/reservation-settings.yml
@@ -1,0 +1,58 @@
+---
+openingHours:
+  start: "09:00"
+  end: "21:00"
+maxCapacityPerSlot: 40
+slotInterval: 15
+timezone: "Europe/Vienna"
+waitlistEnabled: true
+defaultSlots:
+  - time: "09:00"
+    capacity: 40
+  - time: "09:30"
+    capacity: 40
+  - time: "10:00"
+    capacity: 40
+  - time: "10:30"
+    capacity: 40
+  - time: "11:00"
+    capacity: 40
+  - time: "11:30"
+    capacity: 40
+  - time: "12:00"
+    capacity: 40
+  - time: "12:30"
+    capacity: 40
+  - time: "13:00"
+    capacity: 40
+  - time: "13:30"
+    capacity: 40
+  - time: "14:00"
+    capacity: 40
+  - time: "14:30"
+    capacity: 40
+  - time: "15:00"
+    capacity: 40
+  - time: "15:30"
+    capacity: 40
+  - time: "16:00"
+    capacity: 40
+  - time: "16:30"
+    capacity: 40
+  - time: "17:00"
+    capacity: 40
+  - time: "17:30"
+    capacity: 40
+  - time: "18:00"
+    capacity: 40
+  - time: "18:30"
+    capacity: 40
+  - time: "19:00"
+    capacity: 40
+  - time: "19:30"
+    capacity: 40
+  - time: "20:00"
+    capacity: 40
+  - time: "20:30"
+    capacity: 40
+---

--- a/index.html
+++ b/index.html
@@ -514,83 +514,87 @@
         submitButton.disabled = true;
       }
 
-      loadAvailableSlots(dateData.date);
+      loadAvailableTimeSlots(dateData.date);
     }
 
-    async function loadAvailableSlots(selectedDateValue) {
+    async function loadAvailableTimeSlots(date) {
       const slotsContainer = document.getElementById('time-slots-container');
       if (!slotsContainer) return;
 
       slotsContainer.innerHTML = '<div class="loading">Lade verfügbare Zeiten...</div>';
 
       try {
-        const params = new URLSearchParams({ date: selectedDateValue });
-        const response = await fetch(`/.netlify/functions/get-availability?${params.toString()}`);
+        const response = await fetch(`/.netlify/functions/get-availability?date=${date}&guests=2`);
+
         if (!response.ok) {
-          throw new Error('Fehler beim Abrufen der verfügbaren Zeiten');
+          throw new Error(`HTTP error! status: ${response.status}`);
         }
 
         const data = await response.json();
-        const slots = Array.isArray(data.slots) ? data.slots : [];
 
-        if (!slots.length) {
-          slotsContainer.innerHTML = '<div class="no-slots">Keine Zeiten verfügbar für diesen Tag.</div>';
+        if (!data.slots || data.slots.length === 0) {
+          slotsContainer.innerHTML = '<div class="no-slots">Keine verfügbaren Zeitslots für dieses Datum.</div>';
           return;
         }
 
-        slotsContainer.innerHTML = slots
-          .map((slot) => {
-            const capacity = Number(slot.capacity) || 0;
-            const reserved = Number(slot.reserved) || 0;
-            const remaining = Math.max(0, Number(slot.remaining ?? capacity - reserved));
-            const isBlocked = remaining === 0;
-            const isNearlyFull = remaining > 0 && remaining < 5;
-            const usage = capacity > 0 ? Math.min(100, Math.round((reserved / capacity) * 100)) : 100;
-            const blockNote = slot.blockReason ? ` – ${slot.blockReason}` : '';
+        slotsContainer.innerHTML = '';
 
-            return `
-              <div class="time-slot ${isBlocked ? 'blocked' : ''} ${isNearlyFull ? 'nearly-full' : ''}" 
-                   data-time="${slot.time}" 
-                   data-available="${!isBlocked}">
-                  <div class="slot-time">${slot.time}</div>
-                  <div class="slot-availability">
-                      ${isBlocked
-                        ? '<span class="badge blocked">Ausgebucht</span>'
-                        : isNearlyFull
-                          ? `<span class="badge warning">Nur noch ${remaining} Plätze</span>`
-                          : `<span class="badge available">${remaining} Plätze frei</span>`
-                      }
-                  </div>
-                  <div class="slot-capacity-bar">
-                      <div class="capacity-fill" style="width: ${usage}%"></div>
-                  </div>
-                  <div class="slot-details">
-                      ${reserved}/${capacity} belegt${blockNote}
-                  </div>
-              </div>
-            `;
-          })
-          .join('');
+        data.slots.forEach((slot) => {
+          const slotDiv = document.createElement('div');
+          slotDiv.className = `time-slot ${slot.remaining > 0 ? 'available' : 'blocked'}`;
+          slotDiv.dataset.time = slot.time;
+          slotDiv.dataset.available = slot.remaining > 0;
+          slotDiv.dataset.waitlist = slot.waitlist ? 'true' : 'false';
 
-        document.querySelectorAll('.time-slot[data-available="true"]').forEach((slotElement) => {
-          slotElement.addEventListener('click', function handleSlotClick() {
-            selectTimeSlot(this);
-          });
-        });
+          let statusText = '';
+          if (slot.remaining > 0) {
+            statusText = `${slot.remaining} Plätze frei`;
+          } else if (slot.waitlist) {
+            statusText = 'Warteliste';
+          } else if (slot.blockedReason) {
+            statusText = slot.blockedReason;
+          } else {
+            statusText = 'Ausgebucht';
+          }
 
-        document.querySelectorAll('.time-slot[data-available="false"]').forEach((slotElement) => {
-          slotElement.addEventListener('click', () => {
-            showNotification('Dieser Zeitslot ist bereits ausgebucht.', 'error');
-          });
+          const capacity = Number(slot.capacity) || 0;
+          const remaining = Math.max(0, Number(slot.remaining) || 0);
+          const usedCapacity = capacity > 0 ? Math.min(100, ((capacity - remaining) / capacity) * 100) : 100;
+
+          slotDiv.innerHTML = `
+            <div class="slot-time">${slot.time} Uhr</div>
+            <div class="slot-availability">
+              <span class="badge ${slot.remaining > 0 ? 'available' : slot.waitlist ? 'warning' : 'blocked'}">
+                ${statusText}
+              </span>
+            </div>
+            <div class="slot-capacity-bar">
+              <div class="capacity-fill" style="width: ${usedCapacity}%"></div>
+            </div>
+          `;
+
+          if (slot.remaining > 0 || slot.waitlist) {
+            slotDiv.addEventListener('click', () => selectTimeSlot(slotDiv));
+          }
+
+          slotsContainer.appendChild(slotDiv);
         });
       } catch (error) {
-        console.error('Fehler beim Laden der Slots:', error);
-        slotsContainer.innerHTML = '<div class="error">Fehler beim Laden der verfügbaren Zeiten.</div>';
+        console.error('Error loading time slots:', error);
+        slotsContainer.innerHTML = `
+          <div class="error">
+            <p>Fehler beim Laden der verfügbaren Zeiten.</p>
+            <p>Bitte versuchen Sie es später erneut oder kontaktieren Sie uns direkt.</p>
+          </div>
+        `;
       }
     }
 
     function selectTimeSlot(slotElement) {
-      if (slotElement.dataset.available === 'false') {
+      const isAvailable = slotElement.dataset.available !== 'false';
+      const isWaitlist = slotElement.dataset.waitlist === 'true';
+
+      if (!isAvailable && !isWaitlist) {
         showNotification('Dieser Zeitslot ist bereits ausgebucht.', 'error');
         return;
       }

--- a/netlify/functions/get-availability.js
+++ b/netlify/functions/get-availability.js
@@ -1,6 +1,7 @@
-'use strict';
-
-const { getAvailability } = require('./utils/reservation-utils');
+const fs = require('fs').promises;
+const path = require('path');
+const matter = require('gray-matter');
+const yaml = require('js-yaml');
 
 const DEFAULT_HEADERS = {
   'Access-Control-Allow-Origin': '*',
@@ -9,32 +10,122 @@ const DEFAULT_HEADERS = {
   'Content-Type': 'application/json'
 };
 
-function createResponse(statusCode, body) {
-  return {
-    statusCode,
-    headers: DEFAULT_HEADERS,
-    body: JSON.stringify(body)
-  };
+// Load settings from YAML file
+async function loadSettings() {
+  try {
+    const settingsPath = path.join(process.cwd(), 'content', 'settings', 'reservation-settings.yml');
+    const settingsContent = await fs.readFile(settingsPath, 'utf-8');
+    const settings = yaml.load(settingsContent);
+    return settings;
+  } catch (error) {
+    console.error('Error loading settings:', error);
+    return {
+      openingHours: { start: '09:00', end: '21:00' },
+      maxCapacityPerSlot: 40,
+      slotInterval: 15,
+      timezone: 'Europe/Vienna'
+    };
+  }
 }
 
-// CMS Blockierungen laden - MUSS VOR handler definiert werden
-async function loadCMSBlockedReservations(date) {
+// Load blocked slots from markdown files
+async function loadBlockedSlots(date) {
   try {
-    const fs = require('fs').promises;
-    const path = require('path');
-    const filePath = path.join(process.cwd(), 'content', 'blocked-reservations', `${date}.json`);
-
+    const blockedDir = path.join(process.cwd(), 'content', 'blocked-reservations');
+    const filename = `${date}.md`;
+    const filePath = path.join(blockedDir, filename);
+    
     try {
-      const data = await fs.readFile(filePath, 'utf-8');
-      return JSON.parse(data);
+      const content = await fs.readFile(filePath, 'utf-8');
+      const { data } = matter(content);
+      return data.blockedSlots || [];
     } catch {
-      // Datei existiert nicht - das ist OK
+      // No blocked slots for this date
       return [];
     }
   } catch (error) {
-    console.error('Fehler beim Laden der CMS-Blockierungen:', error);
+    console.error('Error loading blocked slots:', error);
     return [];
   }
+}
+
+// Load existing reservations from storage
+async function loadReservations(date) {
+  try {
+    const reservationsPath = path.join(process.cwd(), '.netlify', 'blobs', 'deploy', 'reservations', `${date}.json`);
+    const content = await fs.readFile(reservationsPath, 'utf-8');
+    return JSON.parse(content);
+  } catch {
+    return [];
+  }
+}
+
+// Generate time slots based on settings
+function generateTimeSlots(settings) {
+  const slots = [];
+  const { openingHours, slotInterval } = settings;
+  
+  let [startHour, startMin] = openingHours.start.split(':').map(Number);
+  let [endHour, endMin] = openingHours.end.split(':').map(Number);
+  
+  let currentHour = startHour;
+  let currentMin = startMin;
+  
+  while (currentHour * 60 + currentMin < endHour * 60 + endMin) {
+    const time = `${String(currentHour).padStart(2, '0')}:${String(currentMin).padStart(2, '0')}`;
+    slots.push(time);
+    
+    currentMin += slotInterval;
+    if (currentMin >= 60) {
+      currentHour += Math.floor(currentMin / 60);
+      currentMin = currentMin % 60;
+    }
+  }
+  
+  return slots;
+}
+
+// Calculate availability for each slot
+async function calculateAvailability(date, guests = null) {
+  const settings = await loadSettings();
+  const blockedSlots = await loadBlockedSlots(date);
+  const reservations = await loadReservations(date);
+  
+  const timeSlots = settings.defaultSlots || generateTimeSlots(settings).map(time => ({
+    time,
+    capacity: settings.maxCapacityPerSlot
+  }));
+  
+  const availability = timeSlots.map(slot => {
+    // Check if slot is blocked
+    const blocked = blockedSlots.find(b => b.time === slot.time);
+    const blockedSeats = blocked ? (blocked.blocked_seats || 0) : 0;
+    
+    // Calculate reserved seats
+    const reservedSeats = reservations
+      .filter(r => r.time === slot.time && r.status === 'confirmed')
+      .reduce((sum, r) => sum + (r.guests || 0), 0);
+    
+    const totalCapacity = slot.capacity || settings.maxCapacityPerSlot;
+    const availableCapacity = totalCapacity - blockedSeats;
+    const remaining = Math.max(0, availableCapacity - reservedSeats);
+    
+    return {
+      time: slot.time,
+      capacity: availableCapacity,
+      reserved: reservedSeats,
+      remaining: remaining,
+      waitlist: remaining === 0 && settings.waitlistEnabled,
+      fits: guests ? remaining >= guests : remaining > 0,
+      blockedReason: blocked?.reason
+    };
+  });
+  
+  return {
+    date,
+    timezone: settings.timezone,
+    slots: availability
+  };
 }
 
 exports.handler = async (event) => {
@@ -47,51 +138,40 @@ exports.handler = async (event) => {
   }
 
   if (event.httpMethod !== 'GET') {
-    return createResponse(405, { message: 'Methode nicht erlaubt' });
+    return {
+      statusCode: 405,
+      headers: DEFAULT_HEADERS,
+      body: JSON.stringify({ message: 'Method not allowed' })
+    };
   }
 
   const { date, guests } = event.queryStringParameters || {};
 
   if (!date) {
-    return createResponse(400, { message: 'Datum erforderlich' });
+    return {
+      statusCode: 400,
+      headers: DEFAULT_HEADERS,
+      body: JSON.stringify({ message: 'Date parameter is required' })
+    };
   }
 
   try {
-    const availability = await getAvailability({
-      date,
-      guests: guests ? parseInt(guests, 10) : null
-    });
-
-    // CMS Blockierungen laden und anwenden
-    const cmsBlocked = await loadCMSBlockedReservations(date);
-
-    if (Array.isArray(cmsBlocked) && cmsBlocked.length > 0) {
-      availability.slots = (availability.slots || []).map((slot) => {
-        const block = cmsBlocked.find((entry) => entry.time === slot.time);
-        if (block) {
-          const blockedSeats = Number(block.blocked_seats || 0);
-          if (blockedSeats > 0) {
-            const originalCapacity = Number(slot.capacity || 0);
-            const remaining = Number(slot.remaining ?? originalCapacity - Number(slot.reserved || 0));
-            slot.capacity = Math.max(0, originalCapacity - blockedSeats);
-            slot.remaining = Math.max(0, remaining - blockedSeats);
-            slot.cmsBlocked = true;
-            if (block.reason) {
-              slot.blockReason = block.reason;
-            }
-          }
-        }
-        return slot;
-      });
-    }
-
-    return createResponse(200, availability);
+    const availability = await calculateAvailability(date, guests ? parseInt(guests, 10) : null);
+    
+    return {
+      statusCode: 200,
+      headers: DEFAULT_HEADERS,
+      body: JSON.stringify(availability)
+    };
   } catch (error) {
-    console.error('Fehler in get-availability:', error);
-    console.error('Stack trace:', error.stack); // Mehr Debug-Info
-    return createResponse(500, { 
-      message: 'Interner Server Fehler',
-      error: process.env.NODE_ENV === 'development' ? error.message : undefined
-    });
+    console.error('Error in get-availability:', error);
+    return {
+      statusCode: 500,
+      headers: DEFAULT_HEADERS,
+      body: JSON.stringify({ 
+        message: 'Internal server error',
+        error: process.env.NODE_ENV === 'development' ? error.message : undefined
+      })
+    };
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@netlify/functions": "^2.0.0",
         "@sendgrid/mail": "^7.7.0",
         "gray-matter": "^4.0.3",
+        "js-yaml": "^4.1.0",
         "jsonwebtoken": "^9.0.2",
         "jspdf": "^2.5.1",
         "luxon": "^3.4.4",
@@ -300,13 +301,10 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -645,6 +643,28 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/html2canvas": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -714,13 +734,12 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@netlify/functions": "^2.0.0",
     "@sendgrid/mail": "^7.7.0",
     "gray-matter": "^4.0.3",
+    "js-yaml": "^4.1.0",
     "jspdf": "^2.5.1",
     "jsonwebtoken": "^9.0.2",
     "luxon": "^3.4.4",


### PR DESCRIPTION
## Summary
- add structured reservation settings YAML and CMS collection for blocked slots
- refactor get-availability function to read settings, blocked slots, and reservations from CMS-managed files
- update frontend time slot loader to surface errors and waitlist messaging, and include sample blocked slot content

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68e442576690832d82696108fccfe6f6