### PR TITLE
Add CMS-driven reservation time slots

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -117,6 +117,26 @@ collections:
       - {label: "Beschreibung", name: "description", widget: "text"}
       - {label: "Audio Preview", name: "audioAnnouncement", widget: "file", required: false, hint: "MP3 oder WAV Format"}
 
+  - name: "time-slots"
+    label: "Reservierungs-Zeitfenster"
+    folder: "content/time-slots"
+    create: true
+    identifier_field: date
+    slug: "{{year}}-{{month}}-{{day}}"
+    fields:
+      - {label: "Datum", name: "date", widget: "date", format: "YYYY-MM-DD"}
+      - {label: "Öffnungszeit", name: "opening_time", widget: "string", default: "09:00", pattern: ["^([01]?[0-9]|2[0-3]):[0-5][0-9]$", "Format: HH:MM"]}
+      - {label: "Schließzeit", name: "closing_time", widget: "string", default: "21:00", pattern: ["^([01]?[0-9]|2[0-3]):[0-5][0-9]$", "Format: HH:MM"]}
+      - label: "Zeitfenster"
+        name: "slots"
+        widget: "list"
+        summary: "{{fields.time}} - Kapazität: {{fields.capacity}}"
+        fields:
+          - {label: "Uhrzeit", name: "time", widget: "string", pattern: ["^([01]?[0-9]|2[0-3]):[0-5][0-9]$", "Format: HH:MM"]}
+          - {label: "Kapazität", name: "capacity", widget: "number", default: 40, min: 0, max: 100}
+          - {label: "Blockiert", name: "blocked", widget: "boolean", default: false, required: false}
+          - {label: "Grund (bei Blockierung)", name: "reason", widget: "string", required: false}
+
   - name: "pages"
     label: "Seiten"
     label_singular: "Seite"

--- a/content/time-slots/2024-12-25.md
+++ b/content/time-slots/2024-12-25.md
@@ -1,0 +1,55 @@
+---
+date: "2024-12-25"
+opening_time: "10:00"
+closing_time: "18:00"
+slots:
+  - time: "10:00"
+    capacity: 30
+    blocked: false
+  - time: "10:30"
+    capacity: 30
+    blocked: false
+  - time: "11:00"
+    capacity: 40
+    blocked: false
+  - time: "11:30"
+    capacity: 40
+    blocked: false
+  - time: "12:00"
+    capacity: 50
+    blocked: false
+  - time: "12:30"
+    capacity: 50
+    blocked: false
+  - time: "13:00"
+    capacity: 50
+    blocked: false
+  - time: "13:30"
+    capacity: 40
+    blocked: false
+  - time: "14:00"
+    capacity: 40
+    blocked: false
+  - time: "14:30"
+    capacity: 30
+    blocked: true
+    reason: "Reinigung"
+  - time: "15:00"
+    capacity: 30
+    blocked: false
+  - time: "15:30"
+    capacity: 30
+    blocked: false
+  - time: "16:00"
+    capacity: 30
+    blocked: false
+  - time: "16:30"
+    capacity: 20
+    blocked: false
+  - time: "17:00"
+    capacity: 20
+    blocked: false
+  - time: "17:30"
+    capacity: 20
+    blocked: false
+---

--- a/index.html
+++ b/index.html
@@ -517,6 +517,65 @@
       loadAvailableTimeSlots(dateData.date);
     }
 
+    function renderTimeSlot(slot) {
+      const slotElement = document.createElement('button');
+      slotElement.className = 'time-slot';
+      slotElement.type = 'button';
+      slotElement.dataset.time = slot.time;
+      slotElement.dataset.available = slot.remaining > 0 ? 'true' : 'false';
+      slotElement.dataset.waitlist = slot.waitlist ? 'true' : 'false';
+      slotElement.dataset.fits = slot.fits ? 'true' : 'false';
+
+      if (slot.blocked) {
+        slotElement.classList.add('blocked');
+        slotElement.innerHTML = `
+          <div class="slot-time">${slot.time}</div>
+          <div class="slot-availability">
+            <span class="badge blocked">Blockiert</span>
+            ${slot.blockReason ? `<div class="block-reason">${slot.blockReason}</div>` : ''}
+          </div>
+        `;
+      } else if (slot.remaining === 0) {
+        slotElement.classList.add('unavailable');
+        slotElement.innerHTML = `
+          <div class="slot-time">${slot.time}</div>
+          <div class="slot-availability">
+            <span class="badge unavailable">Ausgebucht</span>
+          </div>
+        `;
+      } else if (slot.remaining <= 5) {
+        slotElement.classList.add('nearly-full');
+        const fillPercent = slot.capacity > 0
+          ? ((slot.capacity - slot.remaining) / slot.capacity) * 100
+          : 0;
+        slotElement.innerHTML = `
+          <div class="slot-time">${slot.time}</div>
+          <div class="slot-availability">
+            <span class="badge warning">${slot.remaining} Plätze frei</span>
+          </div>
+          <div class="slot-capacity-bar">
+            <div class="capacity-fill" style="width: ${fillPercent}%"></div>
+          </div>
+        `;
+      } else {
+        slotElement.classList.add('available');
+        const fillPercent = slot.capacity > 0
+          ? ((slot.capacity - slot.remaining) / slot.capacity) * 100
+          : 0;
+        slotElement.innerHTML = `
+          <div class="slot-time">${slot.time}</div>
+          <div class="slot-availability">
+            <span class="badge available">${slot.remaining} Plätze frei</span>
+          </div>
+          <div class="slot-capacity-bar">
+            <div class="capacity-fill" style="width: ${fillPercent}%"></div>
+          </div>
+        `;
+      }
+
+      return slotElement;
+    }
+
     async function loadAvailableTimeSlots(date) {
       const slotsContainer = document.getElementById('time-slots-container');
       if (!slotsContainer) return;
@@ -539,49 +598,14 @@
 
         slotsContainer.innerHTML = '';
 
-        data.slots.forEach(slot => {
-          const slotDiv = document.createElement('div');
-          const capacity = Number(slot.capacity) || 0;
-          const remaining = Number(slot.remaining) || 0;
-          const usedCapacity = Math.max(0, capacity - remaining);
-          const usagePercent = capacity > 0 ? Math.min(100, (usedCapacity / capacity) * 100) : 0;
-          const slotStateClass = remaining > 0 ? 'available' : slot.waitlist ? 'blocked waitlist' : 'blocked';
+        data.slots.forEach((slot) => {
+          const slotElement = renderTimeSlot(slot);
 
-          slotDiv.className = `time-slot ${slotStateClass}`.trim();
-          slotDiv.dataset.time = slot.time;
-          slotDiv.dataset.available = (remaining > 0 || slot.waitlist).toString();
-          slotDiv.dataset.waitlist = slot.waitlist ? 'true' : 'false';
-
-          let statusText = '';
-          if (remaining > 0) {
-            statusText = `${remaining} Plätze frei`;
-          } else if (slot.waitlist) {
-            statusText = 'Warteliste';
-          } else if (slot.blockedReason) {
-            statusText = slot.blockedReason;
-          } else {
-            statusText = 'Ausgebucht';
+          if (slot.remaining > 0) {
+            slotElement.addEventListener('click', () => selectTimeSlot(slotElement));
           }
 
-          const badgeClass = remaining > 0 ? 'available' : slot.waitlist ? 'warning' : 'blocked';
-
-          slotDiv.innerHTML = `
-            <div class="slot-time">${slot.time} Uhr</div>
-            <div class="slot-availability">
-              <span class="badge ${badgeClass}">
-                ${statusText}
-              </span>
-            </div>
-            <div class="slot-capacity-bar">
-              <div class="capacity-fill" style="width: ${usagePercent}%"></div>
-            </div>
-          `;
-
-          if (remaining > 0 || slot.waitlist) {
-            slotDiv.addEventListener('click', () => selectTimeSlot(slotDiv));
-          }
-
-          slotsContainer.appendChild(slotDiv);
+          slotsContainer.appendChild(slotElement);
         });
       } catch (error) {
         console.error('Error loading time slots:', error);


### PR DESCRIPTION
## Summary
- add a Netlify CMS collection for managing reservation time slots and example content
- load CMS-provided time slot definitions in the reservation utility with a fallback to generated slots
- refresh the front-end time slot rendering to highlight blocked and low-capacity slots

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e45036c470832d88de978c15002e46