### PR TITLE
Support CMS-defined reservation time slots

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -224,3 +224,23 @@ collections:
           - {label: "Zeit", name: "time", widget: "select", options: ["09:00", "09:30", "10:00", "10:30", "11:00", "11:30", "12:00", "12:30", "13:00", "13:30", "14:00", "14:30", "15:00", "15:30", "16:00", "16:30", "17:00", "17:30", "18:00", "18:30", "19:00", "19:30", "20:00", "20:30"]}
           - {label: "Blockierte Plätze", name: "blocked_seats", widget: "number", min: 0, max: 40}
           - {label: "Grund", name: "reason", widget: "string", required: false, hint: "Optional: Grund für Blockierung"}
+
+  - name: "time-slots"
+    label: "Reservierungs-Zeitfenster"
+    folder: "content/time-slots"
+    create: true
+    identifier_field: date
+    slug: "{{year}}-{{month}}-{{day}}"
+    fields:
+      - {label: "Datum", name: "date", widget: "date", format: "YYYY-MM-DD"}
+      - {label: "Öffnungszeit", name: "opening_time", widget: "string", default: "09:00", pattern: ["^([01]?[0-9]|2[0-3]):[0-5][0-9]$", "Format: HH:MM"]}
+      - {label: "Schließzeit", name: "closing_time", widget: "string", default: "21:00", pattern: ["^([01]?[0-9]|2[0-3]):[0-5][0-9]$", "Format: HH:MM"]}
+      - label: "Zeitfenster"
+        name: "slots"
+        widget: "list"
+        summary: "{{fields.time}} - Kapazität: {{fields.capacity}}"
+        fields:
+          - {label: "Uhrzeit", name: "time", widget: "string", pattern: ["^([01]?[0-9]|2[0-3]):[0-5][0-9]$", "Format: HH:MM"]}
+          - {label: "Kapazität", name: "capacity", widget: "number", default: 40, min: 0, max: 100}
+          - {label: "Blockiert", name: "blocked", widget: "boolean", default: false, required: false}
+          - {label: "Grund (bei Blockierung)", name: "reason", widget: "string", required: false}

--- a/content/time-slots/2024-12-25.md
+++ b/content/time-slots/2024-12-25.md
@@ -1,0 +1,55 @@
+---
+date: "2024-12-25"
+opening_time: "10:00"
+closing_time: "18:00"
+slots:
+  - time: "10:00"
+    capacity: 30
+    blocked: false
+  - time: "10:30"
+    capacity: 30
+    blocked: false
+  - time: "11:00"
+    capacity: 40
+    blocked: false
+  - time: "11:30"
+    capacity: 40
+    blocked: false
+  - time: "12:00"
+    capacity: 50
+    blocked: false
+  - time: "12:30"
+    capacity: 50
+    blocked: false
+  - time: "13:00"
+    capacity: 50
+    blocked: false
+  - time: "13:30"
+    capacity: 40
+    blocked: false
+  - time: "14:00"
+    capacity: 40
+    blocked: false
+  - time: "14:30"
+    capacity: 30
+    blocked: true
+    reason: "Reinigung"
+  - time: "15:00"
+    capacity: 30
+    blocked: false
+  - time: "15:30"
+    capacity: 30
+    blocked: false
+  - time: "16:00"
+    capacity: 30
+    blocked: false
+  - time: "16:30"
+    capacity: 20
+    blocked: false
+  - time: "17:00"
+    capacity: 20
+    blocked: false
+  - time: "17:30"
+    capacity: 20
+    blocked: false
+---

--- a/index.html
+++ b/index.html
@@ -517,6 +517,78 @@
       loadAvailableTimeSlots(dateData.date);
     }
 
+    function renderTimeSlot(slot) {
+      const slotElement = document.createElement('button');
+      slotElement.type = 'button';
+      slotElement.className = 'time-slot';
+      slotElement.dataset.time = slot.time;
+      slotElement.dataset.available = slot.fits ? 'true' : 'false';
+      slotElement.dataset.waitlist = slot.waitlist ? 'true' : 'false';
+
+      const capacity = Number(slot.capacity) || 0;
+      const remaining = Number(slot.remaining) || 0;
+      const usedCapacity = Math.max(0, capacity - remaining);
+      const usagePercent = capacity > 0 ? Math.min(100, (usedCapacity / capacity) * 100) : 0;
+
+      if (slot.blocked) {
+        slotElement.classList.add('blocked');
+        slotElement.disabled = true;
+        slotElement.innerHTML = `
+      <div class="slot-time">${slot.time}</div>
+      <div class="slot-availability">
+        <span class="badge blocked">Blockiert</span>
+        ${slot.blockReason ? `<div class="block-reason">${slot.blockReason}</div>` : ''}
+      </div>
+    `;
+      } else if (slot.remaining === 0) {
+        slotElement.classList.add('unavailable');
+        const statusLabel = slot.waitlist ? 'Warteliste' : 'Ausgebucht';
+        const badgeClass = slot.waitlist ? 'warning' : 'unavailable';
+        slotElement.innerHTML = `
+      <div class="slot-time">${slot.time}</div>
+      <div class="slot-availability">
+        <span class="badge ${badgeClass}">${statusLabel}</span>
+        ${slot.blockReason && !slot.waitlist ? `<div class="block-reason">${slot.blockReason}</div>` : ''}
+      </div>
+    `;
+        if (slot.waitlist) {
+          slotElement.classList.add('waitlist');
+          slotElement.dataset.available = 'true';
+          slotElement.disabled = false;
+        } else {
+          slotElement.disabled = true;
+        }
+      } else if (slot.remaining <= 5) {
+        slotElement.classList.add('nearly-full');
+        slotElement.innerHTML = `
+      <div class="slot-time">${slot.time}</div>
+      <div class="slot-availability">
+        <span class="badge warning">${slot.remaining} Plätze frei</span>
+      </div>
+      <div class="slot-capacity-bar">
+        <div class="capacity-fill" style="width: ${usagePercent}%"></div>
+      </div>
+    `;
+      } else {
+        slotElement.classList.add('available');
+        slotElement.innerHTML = `
+      <div class="slot-time">${slot.time}</div>
+      <div class="slot-availability">
+        <span class="badge available">${slot.remaining} Plätze frei</span>
+      </div>
+      <div class="slot-capacity-bar">
+        <div class="capacity-fill" style="width: ${usagePercent}%"></div>
+      </div>
+    `;
+      }
+
+      if (slot.source === 'cms') {
+        slotElement.classList.add('cms-controlled');
+      }
+
+      return slotElement;
+    }
+
     async function loadAvailableTimeSlots(date) {
       const slotsContainer = document.getElementById('time-slots-container');
       if (!slotsContainer) return;
@@ -539,49 +611,14 @@
 
         slotsContainer.innerHTML = '';
 
-        data.slots.forEach(slot => {
-          const slotDiv = document.createElement('div');
-          const capacity = Number(slot.capacity) || 0;
-          const remaining = Number(slot.remaining) || 0;
-          const usedCapacity = Math.max(0, capacity - remaining);
-          const usagePercent = capacity > 0 ? Math.min(100, (usedCapacity / capacity) * 100) : 0;
-          const slotStateClass = remaining > 0 ? 'available' : slot.waitlist ? 'blocked waitlist' : 'blocked';
+        data.slots.forEach((slot) => {
+          const slotElement = renderTimeSlot({ ...slot, source: data.source });
 
-          slotDiv.className = `time-slot ${slotStateClass}`.trim();
-          slotDiv.dataset.time = slot.time;
-          slotDiv.dataset.available = (remaining > 0 || slot.waitlist).toString();
-          slotDiv.dataset.waitlist = slot.waitlist ? 'true' : 'false';
-
-          let statusText = '';
-          if (remaining > 0) {
-            statusText = `${remaining} Plätze frei`;
-          } else if (slot.waitlist) {
-            statusText = 'Warteliste';
-          } else if (slot.blockedReason) {
-            statusText = slot.blockedReason;
-          } else {
-            statusText = 'Ausgebucht';
+          if (slotElement.dataset.available === 'true') {
+            slotElement.addEventListener('click', () => selectTimeSlot(slotElement));
           }
 
-          const badgeClass = remaining > 0 ? 'available' : slot.waitlist ? 'warning' : 'blocked';
-
-          slotDiv.innerHTML = `
-            <div class="slot-time">${slot.time} Uhr</div>
-            <div class="slot-availability">
-              <span class="badge ${badgeClass}">
-                ${statusText}
-              </span>
-            </div>
-            <div class="slot-capacity-bar">
-              <div class="capacity-fill" style="width: ${usagePercent}%"></div>
-            </div>
-          `;
-
-          if (remaining > 0 || slot.waitlist) {
-            slotDiv.addEventListener('click', () => selectTimeSlot(slotDiv));
-          }
-
-          slotsContainer.appendChild(slotDiv);
+          slotsContainer.appendChild(slotElement);
         });
       } catch (error) {
         console.error('Error loading time slots:', error);

--- a/netlify/functions/get-availability.js
+++ b/netlify/functions/get-availability.js
@@ -1,7 +1,6 @@
-const fs = require('fs').promises;
-const path = require('path');
-const matter = require('gray-matter');
-const yaml = require('js-yaml');
+'use strict';
+
+const { getAvailability } = require('./utils/reservation-utils');
 
 const DEFAULT_HEADERS = {
   'Access-Control-Allow-Origin': '*',
@@ -9,178 +8,6 @@ const DEFAULT_HEADERS = {
   'Access-Control-Allow-Methods': 'GET, OPTIONS',
   'Content-Type': 'application/json'
 };
-
-// Load settings from YAML file
-async function loadSettings() {
-  try {
-    const settingsPath = path.join(process.cwd(), 'content', 'settings', 'reservation-settings.yml');
-    const settingsContent = await fs.readFile(settingsPath, 'utf-8');
-    const settings = yaml.load(settingsContent);
-    return settings;
-  } catch (error) {
-    console.error('Error loading settings:', error);
-    return {
-      openingHours: { start: '09:00', end: '21:00' },
-      maxCapacityPerSlot: 40,
-      slotInterval: 15,
-      timezone: 'Europe/Vienna'
-    };
-  }
-}
-
-// Load blocked slots from markdown files
-async function loadBlockedSlots(date) {
-  try {
-    const blockedDir = path.join(process.cwd(), 'content', 'blocked-reservations');
-    const filename = `${date}.md`;
-    const filePath = path.join(blockedDir, filename);
-    
-    try {
-      const content = await fs.readFile(filePath, 'utf-8');
-      const { data } = matter(content);
-      const slots = Array.isArray(data.blockedSlots) ? data.blockedSlots : [];
-
-      return slots
-        .map(entry => {
-          const timeValue = entry?.time ?? entry?.Time ?? null;
-          if (!timeValue) {
-            return null;
-          }
-
-          const blockedValue = Number(entry.blocked_seats ?? entry.blockedSeats ?? entry.capacity ?? 0);
-
-          return {
-            time: String(timeValue),
-            blocked_seats: Number.isFinite(blockedValue) ? blockedValue : 0,
-            reason: entry?.reason ?? entry?.Reason ?? null
-          };
-        })
-        .filter(Boolean);
-    } catch {
-      // No blocked slots for this date
-      return [];
-    }
-  } catch (error) {
-    console.error('Error loading blocked slots:', error);
-    return [];
-  }
-}
-
-// Load existing reservations from storage
-async function loadReservations(date) {
-  try {
-    const reservationsPath = path.join(process.cwd(), '.netlify', 'blobs', 'deploy', 'reservations', `${date}.json`);
-    const content = await fs.readFile(reservationsPath, 'utf-8');
-    return JSON.parse(content);
-  } catch {
-    return [];
-  }
-}
-
-// Generate time slots based on settings
-function generateTimeSlots(settings) {
-  const slots = [];
-  const { openingHours, slotInterval } = settings;
-  
-  let [startHour, startMin] = openingHours.start.split(':').map(Number);
-  let [endHour, endMin] = openingHours.end.split(':').map(Number);
-  
-  let currentHour = startHour;
-  let currentMin = startMin;
-  
-  while (currentHour * 60 + currentMin < endHour * 60 + endMin) {
-    const time = `${String(currentHour).padStart(2, '0')}:${String(currentMin).padStart(2, '0')}`;
-    slots.push(time);
-    
-    currentMin += slotInterval;
-    if (currentMin >= 60) {
-      currentHour += Math.floor(currentMin / 60);
-      currentMin = currentMin % 60;
-    }
-  }
-  
-  return slots;
-}
-
-// Calculate availability for each slot
-async function calculateAvailability(date, guests = null) {
-  const settings = await loadSettings();
-  const blockedSlots = await loadBlockedSlots(date);
-  const reservations = await loadReservations(date);
-
-  const configuredSlots = Array.isArray(settings.defaultSlots) && settings.defaultSlots.length > 0
-    ? settings.defaultSlots
-    : generateTimeSlots(settings).map(time => ({
-        time,
-        capacity: settings.maxCapacityPerSlot
-      }));
-
-  const timeSlots = configuredSlots
-    .map(slot => {
-      if (typeof slot === 'string') {
-        return {
-          time: String(slot),
-          capacity: settings.maxCapacityPerSlot
-        };
-      }
-
-      if (slot && typeof slot === 'object') {
-        const timeValue = slot.time ?? slot.Time ?? null;
-        if (!timeValue) {
-          return null;
-        }
-
-        return {
-          time: String(timeValue),
-          capacity: slot.capacity ?? settings.maxCapacityPerSlot
-        };
-      }
-
-      return null;
-    })
-    .filter(Boolean);
-
-  const availability = timeSlots.map(slot => {
-    const blocked = blockedSlots.find(b => b.time === slot.time);
-    const blockedValue = blocked ? Number(blocked.blocked_seats ?? blocked.blockedSeats ?? 0) : 0;
-    const blockedSeats = Number.isFinite(blockedValue) ? blockedValue : 0;
-
-    const reservedSeats = reservations
-      .filter(r => r.time === slot.time && String(r.status || '').toLowerCase() === 'confirmed')
-      .reduce((sum, r) => {
-        const guestCount = Number(r.guests ?? 0);
-        return sum + (Number.isFinite(guestCount) ? guestCount : 0);
-      }, 0);
-
-    const capacityValue = Number(slot.capacity);
-    const fallbackCapacity = Number(settings.maxCapacityPerSlot ?? 0);
-    const slotCapacity = Number.isFinite(capacityValue)
-      ? capacityValue
-      : Number.isFinite(fallbackCapacity)
-        ? fallbackCapacity
-        : 0;
-
-    const availableCapacity = Math.max(0, slotCapacity - blockedSeats);
-    const remaining = Math.max(0, availableCapacity - reservedSeats);
-
-    return {
-      time: slot.time,
-      capacity: availableCapacity,
-      reserved: reservedSeats,
-      remaining,
-      waitlist: remaining === 0 && Boolean(settings.waitlistEnabled),
-      fits: Number.isFinite(guests) ? remaining >= guests : remaining > 0,
-      blockedReason: blocked?.reason || blocked?.Reason || null
-    };
-  });
-
-  return {
-    date,
-    timezone: settings.timezone,
-    slots: availability
-  };
-}
-
 
 exports.handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') {
@@ -210,10 +37,10 @@ exports.handler = async (event) => {
   }
 
   try {
-    const parsedGuests = guests === undefined ? null : Number.parseInt(guests, 10);
-    const guestCount = Number.isFinite(parsedGuests) ? parsedGuests : null;
-    const availability = await calculateAvailability(date, guestCount);
-    
+    const parsedGuests = guests === undefined ? undefined : Number.parseInt(guests, 10);
+    const guestCount = Number.isFinite(parsedGuests) ? parsedGuests : undefined;
+    const availability = await getAvailability({ date, guests: guestCount });
+
     return {
       statusCode: 200,
       headers: DEFAULT_HEADERS,
@@ -224,7 +51,7 @@ exports.handler = async (event) => {
     return {
       statusCode: 500,
       headers: DEFAULT_HEADERS,
-      body: JSON.stringify({ 
+      body: JSON.stringify({
         message: 'Internal server error',
         error: process.env.NODE_ENV === 'development' ? error.message : undefined
       })


### PR DESCRIPTION
## Summary
- add a Netlify CMS collection and example content for defining per-day reservation slots
- load CMS-managed time slots in the availability utilities/API with fallback to generated slots and slot-level blocking support
- refresh the reservation UI rendering to display CMS-driven availability states and indicators

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e45036c470832d88de978c15002e46