### PR TITLE
Fix reservation time slot display formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,6 +404,27 @@
     let selectedDate = null;
     let selectedTime = null;
 
+    function formatTimeSlot(time) {
+      if (typeof time === 'number' || !Number.isNaN(Number(time))) {
+        const totalMinutes = parseInt(time, 10);
+        const hours = Math.floor(totalMinutes / 60);
+        const minutes = totalMinutes % 60;
+        return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+      }
+      if (typeof time === 'string' && time.includes(':')) {
+        return time;
+      }
+      return time;
+    }
+
+    function formatDisplayTime(time) {
+      const formatted = formatTimeSlot(time);
+      if (typeof formatted === 'string' && formatted.toLowerCase().includes('uhr')) {
+        return formatted;
+      }
+      return `${formatted} Uhr`;
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
       if (document.getElementById('available-dates-container')) {
         loadAvailableDates();
@@ -492,14 +513,17 @@
         const slotButton = document.createElement('button');
         slotButton.type = 'button';
         slotButton.className = 'time-slot';
-        slotButton.textContent = slot.time;
-        slotButton.addEventListener('click', (event) => selectTime(slot.time, event.currentTarget));
+        const rawTime = typeof slot === 'object' && slot !== null ? (slot.time ?? slot.slot ?? slot) : slot;
+        const formattedTime = formatTimeSlot(rawTime);
+        slotButton.textContent = formattedTime;
+        slotButton.dataset.time = formattedTime;
+        slotButton.addEventListener('click', (event) => selectTime(formattedTime, event.currentTarget));
         container.appendChild(slotButton);
       });
     }
 
     function selectTime(time, element) {
-      selectedTime = time;
+      selectedTime = formatTimeSlot(time);
 
       document.querySelectorAll('.time-slot').forEach((el) => el.classList.remove('selected'));
       element.classList.add('selected');
@@ -527,7 +551,7 @@
         formTitle.innerHTML = `
           Ihre Angaben<br>
           <small style="font-size: 0.8em; opacity: 0.8;">
-            ${dateStr} um ${selectedTime} Uhr
+            ${dateStr} um ${formatDisplayTime(selectedTime)}
           </small>
         `;
       }
@@ -562,7 +586,7 @@
 
       const formData = {
         date: selectedDate.date,
-        time: selectedTime,
+        time: formatTimeSlot(selectedTime),
         name: document.getElementById('guest-name').value.trim(),
         email: document.getElementById('guest-email').value.trim(),
         phone: document.getElementById('guest-phone').value.trim(),

--- a/netlify/functions/get-available-dates.js
+++ b/netlify/functions/get-available-dates.js
@@ -4,6 +4,39 @@ const fs = require('fs').promises;
 const path = require('path');
 const matter = require('gray-matter');
 
+function formatTimeSlot(time) {
+  if (typeof time === 'number' || !Number.isNaN(Number(time))) {
+    const totalMinutes = parseInt(time, 10);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+  }
+  if (typeof time === 'string' && time.includes(':')) {
+    return time;
+  }
+  return time;
+}
+
+function normalizeSlots(slots) {
+  if (!Array.isArray(slots)) {
+    return [];
+  }
+
+  return slots.map((slot) => {
+    if (slot && typeof slot === 'object') {
+      const timeValue = slot.time ?? slot.slot ?? slot.start ?? slot.startTime ?? slot;
+      return {
+        ...slot,
+        time: formatTimeSlot(timeValue)
+      };
+    }
+    const formattedTime = formatTimeSlot(slot);
+    return {
+      time: formattedTime
+    };
+  });
+}
+
 exports.handler = async (event) => {
   const headers = {
     'Access-Control-Allow-Origin': '*',
@@ -44,7 +77,7 @@ exports.handler = async (event) => {
           return {
             date: data.date,
             title: data.title || 'Verfügbar',
-            slots: data.slots || [],
+            slots: normalizeSlots(data.slots || []),
             note: data.note || ''
           };
         }

--- a/netlify/functions/get-events.js
+++ b/netlify/functions/get-events.js
@@ -2,6 +2,19 @@ const fs = require('fs').promises;
 const path = require('path');
 const matter = require('gray-matter');
 
+function formatTimeSlot(time) {
+  if (typeof time === 'number' || !Number.isNaN(Number(time))) {
+    const totalMinutes = parseInt(time, 10);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+  }
+  if (typeof time === 'string' && time.includes(':')) {
+    return time;
+  }
+  return time;
+}
+
 exports.handler = async (event, context) => {
   // Set CORS headers
   const headers = {
@@ -40,7 +53,7 @@ exports.handler = async (event, context) => {
           date: getNextMonday(),
           description: "erlebe entspannte lounge-klänge während deines brunches!",
           musicStyle: "downtempo, organic house",
-          startTime: "9:00 uhr",
+          startTime: formatTimeSlot('9:00 uhr'),
           active: true
         }
       ];
@@ -72,13 +85,14 @@ exports.handler = async (event, context) => {
             }
             
             // Process the event data from the markdown file
-                       return {
+            return {
               title: data.title,
               artist: data.artist || '',
               date: data.date,
               location: data.location || '',
               body: data.body || content.replace(/^---[\s\S]*?---/, '').trim(), // Get markdown body content
               price: data.price || '',
+              startTime: formatTimeSlot(data.startTime || data.start_time || data.time || ''),
               featuredImage: data.featuredImage || data.image || '',
               audioAnnouncement: data.audioAnnouncement || data.audioPreview || '',
               active: data.active !== false // Default to true unless explicitly set to false
@@ -108,7 +122,7 @@ exports.handler = async (event, context) => {
         location: "Wien",
         description: "Bester DJ",
         musicStyle: "electronic, house",
-        startTime: "19:00 uhr",
+        startTime: formatTimeSlot('19:00 uhr'),
         featuredImage: "/images/uploads/osive.png",
         audioAnnouncement: "/images/uploads/artist1.mp3",
         active: true


### PR DESCRIPTION
## Summary
- add reusable time-slot formatter to the reservation UI and apply it when rendering, selecting, and summarising slots
- normalize slot times returned by Netlify functions so API responses always send HH:MM strings
- ensure event data start times run through the same formatter for consistency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e556e33e64832d8112bb1f99a33e41